### PR TITLE
Feature/custom repo with port

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.gaia_app</groupId>
     <artifactId>gaia</artifactId>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
     <packaging>jar</packaging>
 
     <name>gaia</name>

--- a/src/main/client/app/pages/modules/terraform-image-input.vue
+++ b/src/main/client/app/pages/modules/terraform-image-input.vue
@@ -79,7 +79,7 @@
         return !!this.image.repository;
       },
       isRepositoryValid() {
-        return /^[\w][\w.\-/]{0,127}$/.test(this.image.repository);
+        return /^[\w][\w.\-/:]{0,127}$/.test(this.image.repository);
       },
       isTagNotEmpty() {
         return !!this.image.tag && /^\S*$/.test(this.image.tag);
@@ -112,7 +112,7 @@
       formatRepository(value) {
         if (!value) return '';
         if (!value.includes(':')) return value;
-        [this.image.repository, this.image.tag] = value.split(':');
+        [this.image.host, this.image.repository, this.image.tag] = /(\S*):(\S*)/.exec(value);
         document.getElementById('image_tag').focus();
         return this.image.repository;
       },

--- a/src/main/java/io/gaia_app/modules/bo/TerraformImage.kt
+++ b/src/main/java/io/gaia_app/modules/bo/TerraformImage.kt
@@ -4,7 +4,7 @@ import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Pattern
 
 data class TerraformImage(
-        @field:NotBlank @field:Pattern(regexp = """^[\w][\w.\-\/]{0,127}$""") val repository: String,
+        @field:NotBlank @field:Pattern(regexp = """^[\w][\w.\-\/:]{0,127}$""") val repository: String,
         @field:NotBlank val tag: String) {
 
     fun image() = "$repository:$tag"

--- a/src/main/resources/mustache/terraform.mustache
+++ b/src/main/resources/mustache/terraform.mustache
@@ -2,8 +2,14 @@ set -e
 
 echo '[gaia] using image {{terraformImage}}'
 
-echo '[gaia] installing curl'
-apk -q add curl
+curl --version
+if $? > 0
+then
+  echo '[gaia] installing curl'
+  apk -q add curl
+else
+  echo '[gaia] curl already installed'
+fi
 
 echo '[gaia] cloning {{gitRepositoryUrl}}' | awk '{ sub(/oauth2:(.*)@/, "oauth2:[MASKED]@");}1'
 git clone {{gitRepositoryUrl}} module


### PR DESCRIPTION
## Description

This solves the following issue https://github.com/gaia-app/gaia/issues/729, allowing to use a format such as "my-custom-repository:5000/myterraform/myimage:latest" as custom terraform image. Additionally, this allows optionally install the curl package on the custom image, making it possible to use root-less customer images (such as in openshift per example).

## Checklist for the pull request author

- [x] Tests added for this feature
- [x] Commit messages follow conventions (see [CONTRIBUTING.md](CONTRIBUTING.md))
- [x] Commits are combined ( 1 commit / type and scope )
- [x] Documentation created / updated (if necessary)
- [x] No new sonarqube issues added
- [x] CI pipeline is OK
- [x] Pull request is fast-forward to the `main` branch
- [x] The last commit of this merge request :
    - [x] updates the `pom.xml` to a new minor or major version
    - [x] updates the `CHANGELOG.md`

## Checklist for the project maintainer

- [ ] Review the code, and add a *Review Approval* if everything is ok
- [ ] This pull request will be merged in merge-commit mode
    - (in github or with the CLI, see [CONTRIBUTING.md](CONTRIBUTING.md))

### After the merge

- [ ] Put the tag on the merged commit
    - (in github or with the CLI, see [CONTRIBUTING.md](CONTRIBUTING.md))
- [ ] Follow the pipeline for the tag, which should build & release the package (maven or docker)

## Issues / Links

* Documentation PR : (eg: gaia-app/docs#1)

(Please add issues resolution information when needed)

